### PR TITLE
Log level is now configurable through env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 There is confustion about api vs service. Unlike openstack documentation, the library calls apis services. This exporter sticks to documentation. APIs are refered to as api not service.
 An API is then build using multiple microservices.
 
-e.g. 
+e.g.
 
 - API: nova
 - Micro Services: nova-compute, nova-api, nova-conductor, nova-scheduler, ...
 
 ## Environment
 
-Standard following standard openstack authentication env-variables: 
+Standard following standard openstack authentication env-variables:
 - OS_AUTH_URL
 - OS_USERNAME
 - OS_PASSWORD
@@ -29,6 +29,8 @@ Other config parameters:
   - how often the exporter should refresh it's data. Default = 60
 * OS_EXPORTER_METRIC_PREFIX
   - prometheus metric names prefix. Default = 'openstack'
+* OS_EXPORTER_LOG_LEVEL
+  - logging level. Must be one of DEBUG, INFO, WARNING or ERROR. Default = "INFO"
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Standard following standard openstack authentication env-variables:
 
 Other config parameters:
 
-* LISTEN PORT
+* OS_EXPORTER_LISTEN_PORT
   - port to bind to. Default: 9103
 * OS_EXPORTER_API_EXCLUDE
   - coma separated list of APIs that should not be polled. Use project name from keystone catalog. E.g. designate not dns... Default: ''

--- a/openstack-exporter/openstack-exporter.py
+++ b/openstack-exporter/openstack-exporter.py
@@ -16,12 +16,20 @@ from prometheus_client import start_http_server
 
 from collector import Collector
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s:%(levelname)s:%(message)s"
-    )
-
 LOGGER = logging.getLogger(__name__)
+
+def configure_logging():
+    """
+    Retrieve logging config from the environment and configure accordingly.
+    """
+    verbosity = os.getenv('OS_EXPORTER_LOG_LEVEL', default="INFO")
+    if verbosity not in ["DEBUG", "INFO", "WARNING", "ERROR"]:
+        verbosity = "INFO"
+    logging.basicConfig(
+        level=verbosity,
+        format="%(asctime)s:%(levelname)s:%(message)s"
+    )
+    LOGGER.info("Logging configured.")
 
 def get_config():
     """
@@ -49,6 +57,8 @@ def get_config():
 
 
 if __name__ == '__main__':
+
+    configure_logging()
 
     CONFIG = get_config()
 


### PR DESCRIPTION
Right now the openstack-exporter has log level hardcoded to INFO.
It's not so practical to troubleshoot issues.

I suggest adding another env variable to allow configuration of the log level.