### PR TITLE
LB collection performance tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 There is confustion about api vs service. Unlike openstack documentation, the library calls apis services. This exporter sticks to documentation. APIs are refered to as api not service.
 An API is then build using multiple microservices.
 
-e.g. 
+e.g.
 
 - API: nova
 - Micro Services: nova-compute, nova-api, nova-conductor, nova-scheduler, ...
 
 ## Environment
 
-Standard following standard openstack authentication env-variables: 
+Standard following standard openstack authentication env-variables:
 - OS_AUTH_URL
 - OS_USERNAME
 - OS_PASSWORD
@@ -29,6 +29,12 @@ Other config parameters:
   - how often the exporter should refresh it's data. Default = 60
 * OS_EXPORTER_METRIC_PREFIX
   - prometheus metric names prefix. Default = 'openstack'
+
+The following environment variables may be use to tune the collections:
+* OS_EXPORTER_LB_COLLECT_LB_STATS
+  - whether or not to collect the load balancers stats. This has performance impact. Default = True.
+* OS_EXPORTER_LB_COLLECT_MEMBER_STATS
+  - whether or not to collect the load balancers member stats. This has performance impact. Default = True.
 
 ## Usage
 

--- a/openstack-exporter/openstack-exporter.py
+++ b/openstack-exporter/openstack-exporter.py
@@ -29,6 +29,7 @@ def get_config():
     """
 
     configuration = {}
+    configuration["load_balancer"] = dict()
 
     # check that mandatory openstack environment variables are present
     # we don't read them into config since openstacksdk get's them directly from the environment
@@ -40,10 +41,14 @@ def get_config():
             sys.exit(1)
 
     # coma separated list of api to be ignored in polling
-    configuration['api-exclude'] = os.getenv('OS_EXPORTER_API_EXCLUDE', default="").split(',')
     configuration['listen-port'] = os.getenv('OS_EXPORTER_LISTEN_PORT', default=9103)
     configuration['metric_prefix'] = os.getenv('OS_EXPORTER_METRIC_PREFIX', default='openstack')
     configuration['interval'] = os.getenv('OS_EXPORTER_INTERVAL_SECONDS', default='60')
+
+    # colllection specific config
+    configuration['api-exclude'] = os.getenv('OS_EXPORTER_API_EXCLUDE', default="").split(',')
+    configuration['load_balancer']['collect_member_stats'] = os.getenv("OS_EXPORTER_LB_COLLECT_MEMBER_STATS", "True").lower() in (True, 'true', '1', 't')
+    configuration['load_balancer']['collect_lb_stats'] = os.getenv("OS_EXPORTER_LB_COLLECT_LB_STATS", "True").lower() in (True, 'true', '1', 't')
 
     return configuration
 


### PR DESCRIPTION
# The problem

In some scenarios, the requests sent by exporter are too expansive and may kill Octavia performance.
In an environment with Octavia 5.1.1 and with some loadbalancer having many listeners and members, it was observed that collecting the LB stats could take up to 5 minutes. In this environment, the exporter kills Octavia performance and is too slow.

# The solution

The most intense requests are:
- the one retrieving the stats of the LB: it has to iterate over all the listeners
- the one retrieving the stats of the members: it has to iterate over all the members

In many scenarios, these metrics could be sacrificed for improve performance.
Thus this PR proposes to disable the collection of LB stats and LB member stats.
Note that LB status and info are still exposed.


