### PR TITLE
Feature/lb collection performance update

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 There is confustion about api vs service. Unlike openstack documentation, the library calls apis services. This exporter sticks to documentation. APIs are refered to as api not service.
 An API is then build using multiple microservices.
 
-e.g. 
+e.g.
 
 - API: nova
 - Micro Services: nova-compute, nova-api, nova-conductor, nova-scheduler, ...
 
 ## Environment
 
-Standard following standard openstack authentication env-variables: 
+Standard following standard openstack authentication env-variables:
 - OS_AUTH_URL
 - OS_USERNAME
 - OS_PASSWORD
@@ -29,6 +29,12 @@ Other config parameters:
   - how often the exporter should refresh it's data. Default = 60
 * OS_EXPORTER_METRIC_PREFIX
   - prometheus metric names prefix. Default = 'openstack'
+
+The following environment variables may be use to tune the collections:
+* OS_EXPORTER_LB_COLLECT_LB_STATS
+  - whether or not to collect the load balancers stats. This has performance impact. Default = True.
+* OS_EXPORTER_LB_COLLECT_MEMBER_STATS
+  - whether or not to collect the load balancers member stats. This has performance impact. Default = True.
 
 ## Usage
 

--- a/openstack-exporter/collector_api_load_balancer.py
+++ b/openstack-exporter/collector_api_load_balancer.py
@@ -62,7 +62,7 @@ class CollectorAPILoadBalancer(CollectorAPIBase):
             self.name_prefix + 'lb_provisioning_status', '', lb_labels,
             states=provisioning_statuses)
 
-        if self.config['load_balancer']['collect_member_stats']:
+        if self.config['load_balancer']['collect_lb_stats']:
             self.lb_gauges = {
                 'lb_active_connections':'active_connections',
             }

--- a/openstack-exporter/collector_api_load_balancer.py
+++ b/openstack-exporter/collector_api_load_balancer.py
@@ -167,34 +167,6 @@ class CollectorAPILoadBalancer(CollectorAPIBase):
                     self.data['project_name'][lb.project_id] = project.name
                     project_name = project.name
 
-<<<<<<< HEAD
-=======
-
-            try:
-                self.disable_stats_collection()
-                stats = self.openstack.load_balancer.get_load_balancer_statistics(lb.id)
-                self.enable_stats_collection()
-            # pylint: disable=fixme, bare-except
-            except:
-                # It's possible that the lb disapears before retrieving the stats
-                # -> we just ignore it then.
-                stats = None
-                self.enable_stats_collection()
-            if stats:
-                for measurement, attribute in self.lb_gauges.items():
-                    self.metrics[measurement].labels(*list(item)).set(stats[attribute])
-                for measurement, attribute in self.lb_couters.items():
-                    if item in self.data['lb_counters_current'][measurement]:
-                        diff = stats[attribute] - self.data['lb_counters_current'][measurement][item]
-                        if diff > 0:
-                            # it is possible that counters are reset -> the prometheus lib does not like that.
-                            # not sure if ignoreing this fact is the proper thing to do though
-                            self.metrics[measurement].labels(*list(item)).inc(diff)
-                    else:
-                        self.metrics[measurement].labels(*list(item)).inc(0)
-                    self.data['lb_counters_current'][measurement][item] = stats[attribute]
-
->>>>>>> main
             self.metrics['lb_operating_status'].labels(*list(item)).state(lb.operating_status)
             self.metrics['lb_admin_status'].labels(*list(item)).state(
                 self._admin_state_to_string(lb.is_admin_state_up))
@@ -207,7 +179,6 @@ class CollectorAPILoadBalancer(CollectorAPIBase):
                 'vip_address': lb.vip_address,
                 'vip_port_id': lb.vip_port_id,
             })
-<<<<<<< HEAD
 
             if not self.config['load_balancer']['collect_lb_stats']:
                 LOGGER.debug("LB stats collection is disabled. Skipping.")
@@ -237,8 +208,6 @@ class CollectorAPILoadBalancer(CollectorAPIBase):
                             self.metrics[measurement].labels(*list(item)).inc(0)
                         self.data['lb_counters_current'][measurement][item] = stats[attribute]
 
-=======
->>>>>>> main
         # remove lbs which are no longer present
         for item in self.data['lbs']:
             if item not in current:
@@ -314,7 +283,6 @@ class CollectorAPILoadBalancer(CollectorAPIBase):
 
             ###################
             # member
-<<<<<<< HEAD
             if not self.config['load_balancer']['collect_member_stats']:
                 LOGGER.debug("LB Member stats collection is disabled. Skipping.")
             else:
@@ -349,40 +317,6 @@ class CollectorAPILoadBalancer(CollectorAPIBase):
                         self.savely_remove_labels('member_provisioning_status', member_item)
                         self.savely_remove_labels('member_operating_status', member_item)
                 self.data['members'][pool.id] = current_member
-=======
-            current_member = {}
-            if not pool.id in self.data['members']:
-                self.data['members'][pool.id] = {}
-
-            try:
-                self.disable_stats_collection()
-                for member in self.openstack.load_balancer.members(pool.id):
-                    member_item = (member.id, member.name, pool.project_id, lbs, listeners, pool.id)
-                    current_member[member_item] = 1
-
-                    self.metrics['member_admin_status'].labels(*list(member_item)).state(
-                        self._admin_state_to_string(member.is_admin_state_up))
-                    self.metrics['member_provisioning_status'].labels(*list(member_item)).state(
-                        pool.provisioning_status)
-                    self.metrics['member_operating_status'].labels(*list(member_item)).state(
-                        pool.operating_status)
-                self.enable_stats_collection()
-
-            except ResourceNotFound:
-                # it is possible that the pool was removed in the meantime
-                # -> we ignore the members then.
-                self.enable_stats_collection()
-
-            # remove pools which are no longer present
-            for member_item in self.data['members'][pool.id]:
-                if member_item not in current_member:
-                    LOGGER.debug("Removing member: {}".format(member_item))
-                    self.savely_remove_labels('member_admin_status', member_item)
-                    self.savely_remove_labels('member_provisioning_status', member_item)
-                    self.savely_remove_labels('member_operating_status', member_item)
-            self.data['members'][pool.id] = current_member
-
->>>>>>> main
 
         # remove pools which are no longer present
         for item in self.data['pools']:

--- a/openstack-exporter/openstack-exporter.py
+++ b/openstack-exporter/openstack-exporter.py
@@ -29,6 +29,7 @@ def get_config():
     """
 
     configuration = {}
+    configuration["load_balancer"] = dict()
 
     # check that mandatory openstack environment variables are present
     # we don't read them into config since openstacksdk get's them directly from the environment
@@ -40,10 +41,14 @@ def get_config():
             sys.exit(1)
 
     # coma separated list of api to be ignored in polling
-    configuration['api-exclude'] = os.getenv('OS_EXPORTER_API_EXCLUDE', default="").split(',')
     configuration['listen-port'] = os.getenv('OS_EXPORTER_LISTEN_PORT', default=9103)
     configuration['metric_prefix'] = os.getenv('OS_EXPORTER_METRIC_PREFIX', default='openstack')
     configuration['interval'] = os.getenv('OS_EXPORTER_INTERVAL_SECONDS', default='60')
+
+    # colllection specific config
+    configuration['api-exclude'] = os.getenv('OS_EXPORTER_API_EXCLUDE', default="").split(',')
+    configuration['load_balancer']['collect_member_stats'] = os.getenv("OS_EXPORTER_LB_COLLECT_MEMBER_STATS", "True").lower() in (True, 'true', '1', 't')
+    configuration['load_balancer']['collect_lb_stats'] = os.getenv("OS_EXPORTER_LB_COLLECT_LB_STATS", "True").lower() in (True, 'true', '1', 't')
 
     return configuration
 


### PR DESCRIPTION
# The problem

In some scenarios, the requests sent by exporter are too expansive and may kill Octavia performance.
In an environment with Octavia 5.1.1 and with some loadbalancer having many listeners and members, it was observed that collecting the LB stats could take up to 5 minutes. In this environment, the exporter kills Octavia performance and is too slow.

# The solution

The most intense requests are:
- the one retrieving the stats of the LB: it has to iterate over all the listeners
- the one retrieving the stats of the members: it has to iterate over all the members

In many scenarios, these metrics could be sacrificed for improve performance.
Thus this PR proposes to disable the collection of LB stats and LB member stats.
Note that LB status and info are still exposed.